### PR TITLE
[v6.1] set force_port_listen containers.conf option for WSL

### DIFF
--- a/podman-image/999-podman-machine-wsl.conf
+++ b/podman-image/999-podman-machine-wsl.conf
@@ -1,0 +1,4 @@
+[engine]
+# see https://github.com/podman-container-tools/podman/issues/29377
+# WSL requires tcp port is listen state to active the windows to WSL port forwarding logic.
+force_port_listen = true

--- a/podman-image/Containerfile.WSL
+++ b/podman-image/Containerfile.WSL
@@ -8,6 +8,8 @@ ARG AARDVARK_DNS_PR_NUM=${AARDVARK_DNS_PR_NUM}
 RUN --mount=type=bind,source=/build_common.sh,target=/run/build_common.sh,z \
     /run/build_common.sh
 
+COPY 999-podman-machine-wsl.conf /usr/share/containers/containers.conf.d/999-podman-machine-wsl.conf
+
 # Disable the systemd resolver, the unit cannot be disabled/ or masked
 # https://fedoraproject.org/wiki/Changes/systemd-resolved#Fully_opting_out_of_systemd-resolved_use
 # https://github.com/containers/podman-machine-os/issues/18


### PR DESCRIPTION
Backport of #295

This is a new option more or less only needed on WSL, so only add it there.
see https://github.com/podman-container-tools/podman/issues/29377


(cherry picked from commit 8bedb0a760369c1a9401e1aac8133a8cc766a367)

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
