### PR TITLE
fix WSL port forwarding with dual stack sockets

### DIFF
--- a/podman-image/999-podman-machine-wsl-rootful.conf
+++ b/podman-image/999-podman-machine-wsl-rootful.conf
@@ -1,0 +1,21 @@
+[engine]
+# see https://github.com/podman-container-tools/podman/issues/29377
+# WSL requires tcp port is listen state to active the windows to WSL port forwarding logic.
+force_port_listen = true
+
+[network]
+# WSL is unable to recognize dual stack sockets for its port forwarding:
+# https://github.com/microsoft/WSL/issues/14154
+# Podman by default uses them when no host ip is set for a port binding.
+# With this option we switch the podman config to pass two separate port mappings
+# for ipv4 and ipv6. The only difference here is that we now have twice as many
+# sockets open but otherwise it should work the same and WSL recognizes the v4
+# only socket. It used to work pre podman 6 only because we only bound 0.0.0.0 v4
+# only which was incorrect.
+# Note because we use force_port_listen above it means ::1 is in listen state and
+# because the rootful DNAT firewall rules do not support that it will not be
+# redirected and just hang.
+# That in turn breaks a connecting to "localhost" as it normally tries ::1 first
+# and as it does not get a connection error will not fall back to 127.0.0.1.
+# Thus we can only use the v4 bind address by default as root.
+default_host_ips = ["0.0.0.0"]

--- a/podman-image/999-podman-machine-wsl-rootless.conf
+++ b/podman-image/999-podman-machine-wsl-rootless.conf
@@ -1,0 +1,11 @@
+[network]
+# WSL is unable to recognize dual stack sockets for its port forwarding:
+# https://github.com/microsoft/WSL/issues/14154
+# Pasta and rootless by default use them when no host ip is set for a port binding
+# With this option we switch the podman config to pass two separate port mappings
+# for ipv4 and ipv6. The only difference here is that we now have twice as many
+# sockets open but otherwise it should work the same and WSL recognizes the v4
+# only socket. The old rootlessport forwarder used to had this work around build
+# into its code but we cannot do that with pasta of course and in general it is best
+# to keep this in a extra config not special cases in the code.
+default_host_ips = ["0.0.0.0", "::"]

--- a/podman-image/999-podman-machine-wsl.conf
+++ b/podman-image/999-podman-machine-wsl.conf
@@ -1,4 +1,0 @@
-[engine]
-# see https://github.com/podman-container-tools/podman/issues/29377
-# WSL requires tcp port is listen state to active the windows to WSL port forwarding logic.
-force_port_listen = true

--- a/podman-image/Containerfile.WSL
+++ b/podman-image/Containerfile.WSL
@@ -8,7 +8,8 @@ ARG AARDVARK_DNS_PR_NUM=${AARDVARK_DNS_PR_NUM}
 RUN --mount=type=bind,source=/build_common.sh,target=/run/build_common.sh,z \
     /run/build_common.sh
 
-COPY 999-podman-machine-wsl.conf /usr/share/containers/containers.conf.d/999-podman-machine-wsl.conf
+COPY 999-podman-machine-wsl-rootless.conf /usr/share/containers/containers.rootless.conf.d/999-podman-machine-wsl.conf
+COPY 999-podman-machine-wsl-rootful.conf /usr/share/containers/containers.rootful.conf.d/999-podman-machine-wsl.conf
 
 # Disable the systemd resolver, the unit cannot be disabled/ or masked
 # https://fedoraproject.org/wiki/Changes/systemd-resolved#Fully_opting_out_of_systemd-resolved_use

--- a/verify/basic_test.go
+++ b/verify/basic_test.go
@@ -1,12 +1,18 @@
 package verify
 
 import (
+	"io"
+	"net/http"
 	"runtime"
+	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gexec"
 )
+
+const TESTIMAGE = "quay.io/libpod/testimage:20241011"
 
 var _ = Describe("run basic podman commands", func() {
 	var (
@@ -28,14 +34,13 @@ var _ = Describe("run basic podman commands", func() {
 		})
 	})
 
-	It("Basic ops", func() {
-		imgName := "quay.io/libpod/testimage:20241011"
-		machineName, session, err := mb.initNowWithName()
+	It("Basic ops rootless", func() {
+		machineName, session, err := mb.initNowWithName(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
 		// Pull an image
-		pull := []string{"pull", imgName}
+		pull := []string{"pull", TESTIMAGE}
 		pullSession, err := mb.setCmd(pull).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(pullSession).To(Exit(0))
@@ -46,18 +51,18 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(checkImages).To(Exit(0))
 		Expect(len(checkImages.outputToStringSlice())).To(Equal(1))
-		Expect(checkImages.outputToStringSlice()).To(ContainElement(imgName))
+		Expect(checkImages.outputToStringSlice()).To(ContainElement(TESTIMAGE))
 
 		// Run simple container and check that host-gateway works
 		// https://github.com/containers/podman/issues/21681
-		runCmdDate := []string{"run", "-it", "--add-host=foobar123:host-gateway", imgName, "cat", "/etc/hosts"}
+		runCmdDate := []string{"run", "-it", "--add-host=foobar123:host-gateway", TESTIMAGE, "cat", "/etc/hosts"}
 		runCmdDateSession, err := mb.setCmd(runCmdDate).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(runCmdDateSession).To(Exit(0))
 		Expect(runCmdDateSession.outputToString()).To(ContainSubstring("foobar123"))
 
 		// Run container in background
-		runCmdTop := []string{"run", "-dt", imgName, "top"}
+		runCmdTop := []string{"run", "-dt", TESTIMAGE, "top"}
 		runTopSession, err := mb.setCmd(runCmdTop).run()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(runTopSession).To(Exit(0))
@@ -89,6 +94,14 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(doubleCheckCmdSession).To(Exit(0))
 		Expect(len(doubleCheckCmdSession.outputToStringSlice())).To(Equal(0))
 
+		// pasta and bridge networks use different port forwarding logic, we must validate both
+		verifyNetworking(mb, false, "pasta", "8080")
+
+		networkCmdSession, err := mb.setCmd([]string{"network", "create", "--ipv6", "testnet"}).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(networkCmdSession).To(Exit(0))
+		verifyNetworking(mb, false, "testnet", "8081")
+
 		// systemd-binfmt.service is failing to configure emulation, so we cannot test that there yet
 		// https://github.com/containers/podman/issues/19961
 		if vmTestProvider != WSLVirt {
@@ -105,14 +118,14 @@ var _ = Describe("run basic podman commands", func() {
 				expectedArch = "x86_64"
 			}
 			// quiet to not get the pull output
-			archCommand := []string{"run", "--quiet", "--platform", "linux/" + goArch, imgName, "arch"}
+			archCommand := []string{"run", "--quiet", "--platform", "linux/" + goArch, TESTIMAGE, "arch"}
 			archSession, err := mb.setCmd(archCommand).run()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(archSession).To(Exit(0))
 			Expect(archSession.outputToString()).To(Equal(expectedArch))
 
 			// check that argv[0] is preserved
-			argvTestCommand := []string{"run", "--quiet", "--platform", "linux/" + goArch, imgName, "sh", "-c", "echo $0"}
+			argvTestCommand := []string{"run", "--quiet", "--platform", "linux/" + goArch, TESTIMAGE, "sh", "-c", "echo $0"}
 			argvSession, err := mb.setCmd(argvTestCommand).run()
 			Expect(err).ToNot(HaveOccurred())
 			Expect(argvSession).To(Exit(0))
@@ -134,10 +147,22 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(removeMachineSession).To(Exit(0))
 	})
 
+	It("Basic networking rootful", func() {
+		_, session, err := mb.initNowWithName(true)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(session).To(Exit(0))
+
+		networkCmdSession, err := mb.setCmd([]string{"network", "create", "--ipv6", "testnet"}).run()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(networkCmdSession).To(Exit(0))
+
+		verifyNetworking(mb, true, "testnet", "8082")
+	})
+
 	It("machine stop/start cycle", func() {
 		// We have seen an issue while stopping and starting machines again
 		// and then causing ssh failures on the second start. So test it.
-		machineName, session, err := mb.initNowWithName()
+		machineName, session, err := mb.initNowWithName(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 
@@ -152,3 +177,49 @@ var _ = Describe("run basic podman commands", func() {
 		Expect(startMachineSession).To(Exit(0))
 	})
 })
+
+func verifyNetworking(mb *imageTestBuilder, rootful bool, network string, port string) {
+	const containerName = "http"
+	// verify networking works
+	runCmd := []string{"run", "-d", "-p", port + ":80", "--network", network, "--name", containerName, TESTIMAGE, "/bin/busybox-extras", "httpd", "-f", "-p", "80"}
+	runCmdSession, err := mb.setCmd(runCmd).run()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(runCmdSession).To(Exit(0))
+
+	// Small retry loop in the machine to ensure the http process is up and has bound the port
+	// Otherwise the go code below might connect to early.
+	for range 5 {
+		curlCmd := []string{"machine", "ssh", mb.name, "sudo", "curl", "http://127.0.0.1:" + port}
+		curlSession, err := mb.setCmd(curlCmd).run()
+		Expect(err).ToNot(HaveOccurred())
+		if curlSession.ExitCode() == 0 {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	for _, name := range []string{"localhost", "127.0.0.1", "[::1]"} {
+		if rootful && vmTestProvider == WSLVirt && name == "[::1]" {
+			// on rootful WSL we do not support forwarding on ::1
+			continue
+		}
+		client := http.Client{
+			// USe a custom client with a low timeout to avoid longs hangs on errors
+			Timeout: 5 * time.Second,
+		}
+		// request known file in image
+		url := "http://" + name + ":" + port + "/testimage-id"
+		resp, err := client.Get(url)
+		Expect(err).ToNot(HaveOccurred(), url)
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK), url)
+		bytes, err := io.ReadAll(resp.Body)
+		Expect(err).ToNot(HaveOccurred(), url)
+		_, id, _ := strings.Cut(TESTIMAGE, ":")
+		Expect(string(bytes)).To(Equal(id+"\n"), url)
+	}
+
+	rmCmdSession, err := mb.setCmd([]string{"rm", "-f", "-t0", containerName}).run()
+	Expect(err).ToNot(HaveOccurred())
+	Expect(rmCmdSession).To(Exit(0))
+}

--- a/verify/config_test.go
+++ b/verify/config_test.go
@@ -142,13 +142,18 @@ func (m *imageTestBuilder) run() (*machineSession, error) {
 	return runWrapper(podmanBinary, m.cmd, m.timeout, nil)
 }
 
-func (m *imageTestBuilder) initNowWithName() (string, *machineSession, error) {
+func (m *imageTestBuilder) initNowWithName(rootful bool) (string, *machineSession, error) {
 	machineName := randomString()
 	diskSize := defaultDiskSize
 	if m.diskSize > 0 {
 		diskSize = m.diskSize
 	}
-	cmdLine := []string{"machine", "init", "--now", "--image", m.imagePath, "--disk-size", strconv.Itoa(int(diskSize)), machineName}
+	optRootful := "--rootful=false"
+	if rootful {
+		optRootful = "--rootful"
+	}
+
+	cmdLine := []string{"machine", "init", "--now", "--image", m.imagePath, "--disk-size", strconv.Itoa(int(diskSize)), optRootful, machineName}
 	session, err := m.setName(machineName).setCmd(cmdLine).run()
 	return machineName, session, err
 }

--- a/verify/image_test.go
+++ b/verify/image_test.go
@@ -20,7 +20,7 @@ var _ = Describe("run image tests", Ordered, ContinueOnFailure, func() {
 
 	BeforeAll(func() {
 		testDir, mb = setup()
-		machineName, session, err = mb.initNowWithName()
+		machineName, session, err = mb.initNowWithName(false)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(session).To(Exit(0))
 		DeferCleanup(func() {


### PR DESCRIPTION
Since we use pasta by default now the old dual stack socket work around
from rootlessport no longer applies there. WSL still cannot see dual
stack sockets and thus does not forward the ipv4 connection.
The same goes for Podman since 6.0 we bind a dual stack socket by
default as root.

To work around this we can make use of the new podman 6 config option
default_host_ips to split the ports mappings into two for "0.0.0.0" and
"::" bind addresses which makes it work as WSL will see the v4 one as
well then.

However as rootful we cannot bind + listen on "::" as this will make
localhost connections that try ::1 first not fall back to 127.0.0.1.
To avoid that we only bind 0.0.0.0 as root.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
