### PR TITLE
update Maintainers and Governance to link to community repo

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,3 @@
+# Project Governance
+
+The Podman-machine-os repository, as part of the [Podman Container Tools project](https://www.cncf.io/projects/podman-container-tools), follows the project's governance, which is defined here: https://github.com/podman-container-tools/community/blob/main/GOVERNANCE.md

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,24 +1,16 @@
 # Podman-machine-os Maintainers
 
-[GOVERNANCE.md](https://github.com/containers/podman/blob/main/GOVERNANCE.md)
-describes the Podman project's governance and the Project Roles used below.
+[GOVERNANCE.md](https://github.com/podman-container-tools/community/blob/main/GOVERNANCE.md)
+describes the Podman Container Tools project's governance and the Project Roles used below.
 
-Please note that this file only includes the podman-machine-os subproject's Maintainers and Reviewers.
-Maintainers and Reviewers for the other subprojects are found in their respective repository's MAINTAINERS.md files.
+Please note that this file only includes Podman-machine-os's Maintainers and Reviewers.
+Core Maintainers and Community Managers who act on the behalf of all repositories are only defined in the community repository's [MAINTAINERS.md](https://github.com/podman-container-tools/community/blob/main/MAINTAINERS.md) file.
+Maintainers and Reviewers on other Podman Container Tools projects are found in their respective repository's MAINTAINERS.md files.
 
 ## Maintainers
 
 | Maintainer        | GitHub ID                                                | Project Roles     | Affiliation                                  |
 |-------------------|----------------------------------------------------------|-------------------|----------------------------------------------|
-| Brent Baude       | [baude](https://github.com/baude)                        | Core Maintainer   | [Red Hat](https://github.com/RedHatOfficial) |
-| Nalin Dahyabhai   | [nalind](https://github.com/nalind)                      | Core Maintainer   | [Red Hat](https://github.com/RedHatOfficial) |
-| Matthew Heon      | [mheon](https://github.com/mheon)                        | Core Maintainer   | [Red Hat](https://github.com/RedHatOfficial) |
-| Paul Holzinger    | [Luap99](https://github.com/Luap99)                      | Core Maintainer   | [Red Hat](https://github.com/RedHatOfficial) |
-| Giuseppe Scrivano | [giuseppe](https://github.com/giuseppe)                  | Core Maintainer   | [Red Hat](https://github.com/RedHatOfficial) |
-| Miloslav Trmač    | [mtrmac](https://github.com/mtrmac)                      | Core Maintainer   | [Red Hat](https://github.com/RedHatOfficial) |
-| Mohan Boddu       | [mohanboddu](https://github.com/mohanboddu)              | Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
-| Neil Smith        | [actionmancan](https://github.com/actionmancan)          | Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
-| Tom Sweeney       | [TomSweeneyRedHat](https://github.com/TomSweeneyRedHat/) | Community Manager | [Red Hat](https://github.com/RedHatOfficial) |
 | Ashley Cui        | [ashley-cui](https://github.com/ashley-cui)              | Maintainer        | [Red Hat](https://github.com/RedHatOfficial) |
 | Mario Loriedo     | [l0rd](https://github.com/l0rd/)                         | Maintainer        | [Red Hat](https://github.com/RedHatOfficial) |
 | Lokesh Mandvekar  | [lsm5](https://github.com/lsm5)                          | Maintainer        | [Red Hat](https://github.com/RedHatOfficial) |


### PR DESCRIPTION
With the new community repo we use that as place to define our Governance and the org wide rules. As such we should just link there to avoid duplication and drift.

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
