### PR TITLE
podman-image: drop ostree container commit

### DIFF
--- a/podman-image/Containerfile.COREOS
+++ b/podman-image/Containerfile.COREOS
@@ -16,7 +16,7 @@ ARG AARDVARK_DNS_PR_NUM=${AARDVARK_DNS_PR_NUM}
 ARG FEDORA_VERSION=${FEDORA_VERSION}
 
 RUN --mount=type=bind,source=/build_common.sh,target=/run/build_common.sh,z \
-    /run/build_common.sh && ostree container commit
+    /run/build_common.sh
 
 COPY podman-iptables.conf /etc/modules-load.d/podman-iptables.conf
 


### PR DESCRIPTION
It is failing in the latest next stream image. Per Colin it is not needed so just drop the command to get the build working again.

ref https://github.com/coreos/fedora-coreos-tracker/issues/2145#issuecomment-5359277071

<!--
Thanks for sending a pull request!

Please make your commit messages insightful so we start a decent history. If you
add something to the main Containerfile, please ensure you add a test in `verify/`
so we can protect against regressions.
-->

<!--
If no, just write `None` in the release-note block below. If yes, a release note
is required: Enter your extended release note in the block below. If the PR
requires additional action from users switching to the new release, include the
string "action required".

For more information on release notes, please follow the Kubernetes model:
https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
