### PR TITLE
fix: tweak sshd MaxStartups semantics to achieve desired result

### DIFF
--- a/podman-image/build_common.sh
+++ b/podman-image/build_common.sh
@@ -59,7 +59,7 @@ PerSourcePenalties authfail:0
 
 # If many podman commands are run simultaneously, sshd may drop some of the
 # connections. There are no remote users so set the limit very high.
-MaxStartups 65535
+MaxStartups 65535:1:65535
 EOF
 
 ## Set delegate.conf so cpu,io subsystem is delegated to non-root users as well for cgroupv2


### PR DESCRIPTION
This is fixes https://github.com/podman-container-tools/podman-machine-os/issues/305. 

The current deployed sshd MaxStartups does not achieve the stated desired result of allowing a high number of connections.

```release-note
None
```
